### PR TITLE
Fix number type and remove duplicated token

### DIFF
--- a/coml.ebnf
+++ b/coml.ebnf
@@ -14,24 +14,24 @@ basicTypes ::= number | boolean | string | array | hash | patchKey | patch | "ni
 (* Basic Types: Number *)
 
 digit ::= #'[1-9]';
-natural ::= digit | "0" | natural "0" | digit natural;
-decInteger ::= natural | "-" natural | "+" natural;
+decNatural ::= digit | "0" | decNatural "0" | digit decNatural;
+decInteger ::= decNatural | "-" decNatural | "+" decNatural;
 float ::= decInteger "f"
-        | decInteger "." natural
-        | decInteger "." natural "e" decInteger
-        | decInteger "." natural "E" decInteger;
+        | decInteger "." decNatural
+        | decInteger "." decNatural "e" decInteger
+        | decInteger "." decNatural "E" decInteger;
 
 binDigit ::= #'[0-1]';
-binNature ::= "0b" binDigit+;
-binInteger ::= binNature | "-" binNature | "+" binNature;
+binNatural ::= "0b" binDigit+;
+binInteger ::= binNatural | "-" binNatural | "+" binNatural;
 
 octDigit ::= #'[0-7]';
-octNature ::= "0o" octDigit+ | "0" octDigit+;
-octInteger ::= octNature | "-" octNature | "+" octNature;
+octNatural ::= "0o" octDigit+ | "0" octDigit+;
+octInteger ::= octNatural | "-" octNatural | "+" octNatural;
 
 hexDigit ::= #'[0-9a-fA-F]';
-hexNature ::= "0x" hexDigit+;
-hexInteger ::= hexNature | "-" hexNature | "+" hexNature;
+hexNatural ::= "0x" hexDigit+;
+hexInteger ::= hexNatural | "-" hexNatural | "+" hexNatural;
 
 integer ::= decInteger | binInteger | octInteger | hexInteger;
 number ::= integer | float;

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -14,28 +14,29 @@ basicTypes ::= number | boolean | string | array | hash | patchKey | patch | "ni
 (* Basic Types: Number *)
 
 digit ::= #'[1-9]';
-decNatural ::= digit | "0" | decNatural "0" | digit decNatural;
+decInteger ::= digit | "0" | decInteger "0" | digit decInteger;
 
 exponentIndicator ::= "e" | "E";
-exponentPart ::= exponentIndicator decNatural
-               | exponentIndicator "-" decNatural
-               | exponentIndicator "+" decNatural;
-unsignedFloat ::= decNatural "f"
-               | decNatural "." decNatural exponentPart*;
-float ::= unsignedFloat | "-" unsignedFloat | "+" unsignedFloat;
+exponentPart ::= exponentIndicator decInteger
+               | exponentIndicator "-" decInteger
+               | exponentIndicator "+" decInteger;
+unsignedFloat ::= decInteger "f"
+                | decInteger "." decInteger exponentPart*;
 
 binDigit ::= #'[0-1]';
-binNatural ::= "0b" binDigit+;
+binInteger ::= "0b" binDigit+;
 
 octDigit ::= #'[0-7]';
-octNatural ::= "0o" octDigit+ | "0" octDigit+;
+octInteger ::= "0o" octDigit+ | "0" octDigit+;
 
 hexDigit ::= #'[0-9a-fA-F]';
-hexNatural ::= "0x" hexDigit+;
+hexInteger ::= "0x" hexDigit+;
 
-unsignedInteger ::= decNatural | binNatural | octNatural | hexNatural;
-integer ::= unsignedInteger | "-" unsignedInteger | "+" unsignedInteger;
-number ::= integer | float;
+unsignedInteger ::= decInteger | binInteger | octInteger | hexInteger;
+signedInteger ::= unsignedInteger | "-" unsignedInteger | "+" unsignedInteger;
+signedFloat ::= unsignedFloat | "-" unsignedFloat | "+" unsignedFloat;
+
+number ::= signedInteger | signedFloat;
 
 (* Basic Types: Boolean *)
 
@@ -74,9 +75,9 @@ imports ::= import | import eol+ imports;
 (* Patch *)
 
 patchKey ::= patchKey "." key
-           | patchKey "[" whitespaces? (string | integer) whitespaces? "]"
-           | patchKey "[" whitespaces? integer whitespaces? ".." whitespaces? integer whitespaces? "]"
-           | patchKey "[" whitespaces? integer whitespaces? "..." whitespaces? integer whitespaces? "]"
+           | patchKey "[" whitespaces? (string | signedInteger) whitespaces? "]"
+           | patchKey "[" whitespaces? signedInteger whitespaces? ".." whitespaces? signedInteger whitespaces? "]"
+           | patchKey "[" whitespaces? signedInteger whitespaces? "..." whitespaces? signedInteger whitespaces? "]"
            | key;
 
 patchReplace ::= patchKey whitespaces? "=" splitter? expr;

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -16,10 +16,13 @@ basicTypes ::= number | boolean | string | array | hash | patchKey | patch | "ni
 digit ::= #'[1-9]';
 decNatural ::= digit | "0" | decNatural "0" | digit decNatural;
 decInteger ::= decNatural | "-" decNatural | "+" decNatural;
+
+exponentIndicator ::= "e" | "E";
+exponentPart ::= exponentIndicator decNatural
+               | exponentIndicator "-" decNatural
+               | exponentIndicator "+" decNatural;
 float ::= decInteger "f"
-        | decInteger "." decNatural
-        | decInteger "." decNatural "e" decInteger
-        | decInteger "." decNatural "E" decInteger;
+        | decInteger "." decNatural exponentPart*;
 
 binDigit ::= #'[0-1]';
 binNatural ::= "0b" binDigit+;

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -15,14 +15,14 @@ basicTypes ::= number | boolean | string | array | hash | patchKey | patch | "ni
 
 digit ::= #'[1-9]';
 decNatural ::= digit | "0" | decNatural "0" | digit decNatural;
-decInteger ::= decNatural | "-" decNatural | "+" decNatural;
 
 exponentIndicator ::= "e" | "E";
 exponentPart ::= exponentIndicator decNatural
                | exponentIndicator "-" decNatural
                | exponentIndicator "+" decNatural;
-float ::= decInteger "f"
-        | decInteger "." decNatural exponentPart*;
+unsignedFloat ::= decNatural "f"
+               | decNatural "." decNatural exponentPart*;
+float ::= unsignedFloat | "-" unsignedFloat | "+" unsignedFloat;
 
 binDigit ::= #'[0-1]';
 binNatural ::= "0b" binDigit+;
@@ -33,8 +33,8 @@ octNatural ::= "0o" octDigit+ | "0" octDigit+;
 hexDigit ::= #'[0-9a-fA-F]';
 hexNatural ::= "0x" hexDigit+;
 
-natural ::= decNatural | binNatural | octNatural | hexNatural;
-integer ::= natural | "-" natural | "+" natural;
+unsignedInteger ::= decNatural | binNatural | octNatural | hexNatural;
+integer ::= unsignedInteger | "-" unsignedInteger | "+" unsignedInteger;
 number ::= integer | float;
 
 (* Basic Types: Boolean *)

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -59,7 +59,7 @@ array ::= "[" splitter? arrayElements splitter? "]"
 
 keyCharStart ::= #'[a-zA-Z_]';
 
-keyCharMiddle ::= keyCharStart | decDigit | "_";
+keyCharMiddle ::= keyCharStart | decDigit;
 key ::= keyCharStart keyCharMiddle*;
 hashElement ::= (whitespaces?) key (splitter?) ":" (splitter?) expr;
 hash ::= hashElement | hashElement eol+ hash;

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -23,17 +23,15 @@ float ::= decInteger "f"
 
 binDigit ::= #'[0-1]';
 binNatural ::= "0b" binDigit+;
-binInteger ::= binNatural | "-" binNatural | "+" binNatural;
 
 octDigit ::= #'[0-7]';
 octNatural ::= "0o" octDigit+ | "0" octDigit+;
-octInteger ::= octNatural | "-" octNatural | "+" octNatural;
 
 hexDigit ::= #'[0-9a-fA-F]';
 hexNatural ::= "0x" hexDigit+;
-hexInteger ::= hexNatural | "-" hexNatural | "+" hexNatural;
 
-integer ::= decInteger | binInteger | octInteger | hexInteger;
+natural ::= decNatural | binNatural | octNatural | hexNatural;
+integer ::= natural | "-" natural | "+" natural;
 number ::= integer | float;
 
 (* Basic Types: Boolean *)

--- a/coml.ebnf
+++ b/coml.ebnf
@@ -13,15 +13,16 @@ basicTypes ::= number | boolean | string | array | hash | patchKey | patch | "ni
 
 (* Basic Types: Number *)
 
-digit ::= #'[1-9]';
-decInteger ::= digit | "0" | decInteger "0" | digit decInteger;
+decDigit ::= #'[0-9]';
+nonZeroDecDigit ::= #'[1-9]';
+decInteger ::= "0" | nonZeroDecDigit decDigit*;
 
 exponentIndicator ::= "e" | "E";
-exponentPart ::= exponentIndicator decInteger
-               | exponentIndicator "-" decInteger
-               | exponentIndicator "+" decInteger;
+exponentPart ::= exponentIndicator decDigit+
+               | exponentIndicator "-" decDigit+
+               | exponentIndicator "+" decDigit+;
 unsignedFloat ::= decInteger "f"
-                | decInteger "." decInteger exponentPart*;
+                | decInteger "." decDigit+ exponentPart*;
 
 binDigit ::= #'[0-1]';
 binInteger ::= "0b" binDigit+;
@@ -58,7 +59,7 @@ array ::= "[" splitter? arrayElements splitter? "]"
 
 keyCharStart ::= #'[a-zA-Z_]';
 
-keyCharMiddle ::= keyCharStart | digit | "0" | "_";
+keyCharMiddle ::= keyCharStart | decDigit | "_";
 key ::= keyCharStart keyCharMiddle*;
 hashElement ::= (whitespaces?) key (splitter?) ":" (splitter?) expr;
 hash ::= hashElement | hashElement eol+ hash;


### PR DESCRIPTION
## Problems
1. These float number are invalid: `1.01, 1.101, 1.0e01, 1.0e101`.
2. `"_"` is included in `keyCharStart`, so the `"_"` in `keyCharMiddle` is duplicated.

## Patch
The pull request fixes the above problems and refactor the number part of the file.